### PR TITLE
Remove line from instructions for Laigen downloads

### DIFF
--- a/Laigen1.html
+++ b/Laigen1.html
@@ -35,7 +35,6 @@
 <h2 style="margin:0;">
 <a href="https://castle-engine.io/castle-model-viewer" style="color:lightskyblue;" target="_blank">Castle Model Viewer</a></h2>
 <p style="font-weight:bold;">Castle Model Viewer is needed in order to run Laigen. Once you've downloaded and extracted <i>Laigen2.zip</i>, open Castle Model Viewer, and open <i>Laigen2.wrl</i> in Castle Model Viewer.</p>
-<p style="font-weight:bold;">If you wish to download <i>Laigen2.zip.asc</i>, right-click it and select 'Save link as...'</p>
 </div>
 <br>
 <table width="auto" border="2" cellpadding="10" bgcolor="#673800">


### PR DESCRIPTION
Forgot that I was working off of the disk, not the live site. The 'save link as' is needed when its a file on disk, but on the live site, just left clicking the link for the ASC file downloads it