### PR TITLE
nav menu now works properly on mobile

### DIFF
--- a/Mtest.html
+++ b/Mtest.html
@@ -38,8 +38,8 @@
 </div>
 
 <div class="nav-menu">
-<button class="nav-menu-btn">Site Pages<img src="menu-icon.svg" alt="Menu"></button>
-<div class="nav-menu-content">
+<button href="javascript:void(0);" onclick="toggleMenu()" class="nav-menu-btn">Site Pages<img src="menu-icon.svg" alt="Menu"></button>
+<div class="nav-menu-content" id="dropDownList">
     <a href="/">Home</a>
     <a href="WhatsNew.html">What's New? (Last Update: 19 APR 2026)</a>
     <a href="DailyLog.html">&nbsp;&nbsp;&nbsp;The Daily Log</a>
@@ -150,6 +150,19 @@
 </div>
 </div>
 </footer>
+
+<script>
+function toggleMenu() {
+    var list = document.getElementById("dropDownList");
+    if (outerWidth <= 1280) { /* dont change style if not on mobile, else list gets stuck open */
+        if (list.style.display === "block") {
+            list.style.display = "none";
+        } else {
+            list.style.display = "block";
+        }
+    }
+}
+</script>
 
 </body>
 

--- a/styles.css
+++ b/styles.css
@@ -335,6 +335,10 @@ footer .online-since { /* used to style the 'ONLINE SINCE 1996' text */
         min-width: 300px;
     }
 
+    .nav .nav-menu:hover .nav-menu-btn {
+        background-color: black;
+    }
+
     .main-welcome {
         margin: 0;
     }


### PR DESCRIPTION
On mobile, javascript is used to display the list now. JS is needed in order to make the button <i>toggle</i> the list. Otherwise, in order for a user on mobile to close the menu, they have to tap somewhere outside the list to get it to close. This can be kinda annoying, so best to include it.

I also made sure that if the user is on desktop, then the JS function <b>does not</b> change the list's style.