### PR TITLE
Laigen-Verify.html - Fix note window

### DIFF
--- a/Laigen-Verify.html
+++ b/Laigen-Verify.html
@@ -54,6 +54,7 @@
 <span>gpg:                issuer "bjacullen01@proton.me"</span>
 <span>gpg: Good signature from "Brandon Cullen (Signing Key) &lt;bjacullen01@proton.me&gt;" [unknown]</span>
 </pre><br>
+<div class="note">
 <div class="note-head">
 <b><u>Note</u></b></div>
 <div class="note-body">
@@ -64,6 +65,7 @@
 <p>and the key's fingerprint is:</p>
 <span class="loc">EFBA 7D9E C0EE 464C 489D B45F 8585 F6FE CA38 F889</span>
 <p>then you've verified that <i>Laigen2.zip</i> is intact and has not been tampered with!</p>
+</div>
 </div>
 </div>
 <br>

--- a/styles.css
+++ b/styles.css
@@ -278,6 +278,11 @@ footer .online-since { /* used to style the 'ONLINE SINCE 1996' text */
     line-height: 1.2rem;
 }
 
+.note {
+    display: flex;
+    flex-direction: column;
+}
+
 .note-head { /* This and the block below are used to create a note 'window'. note-head is like the title bar on a window in Windows */
     margin: 0;
     padding: 6px 1em;


### PR DESCRIPTION
Something I did in the CSS file made the note-head and note-body have a space between them. Whoops. Fixed it.