### PR TITLE
Fix two open <a> tags issue

### DIFF
--- a/CullData.html
+++ b/CullData.html
@@ -95,7 +95,7 @@ The guidelines for the content of the material found in the Record Archives has 
 <BR><H3><B>Other Cullen Family Histories Contributed:</B></H3>
 <UL>
 <LI><A HREF="Radford.html">Descendants of Wm & Eliz Cullen (Radford, Nottinghamshire, Eng)</A><BR><I>by Andy Johnson</I></LI>
-<LI><A HREF="Ballyconnigar.html">Descendants of Thomas & Margaret (Murphy) Cullen of Ballyconnigar (Co Wexford, Ireland)<A><BR><I>by Ron & Josephine Lowe</I></LI>
+<LI><A HREF="Ballyconnigar.html">Descendants of Thomas & Margaret (Murphy) Cullen of Ballyconnigar (Co Wexford, Ireland)</A><BR><I>by Ron & Josephine Lowe</I></LI>
 <LI><A HREF="Finian.html">Descendants of William & Sarah (O'Toole) Cullen (Co Wicklow, Ireland)</A><BR><I>by Brendan Cullen of Dublin, Ireland</I></LI>
 <LI><A HREF="CornCull.html">Descendants of Cornelius Cullen (Co Cavan, Ireland)</A><BR><I>by Heather Brownett & Jim Cullen</I></LI>
 <LI><A HREF="FamKent.html">Descendants of Lord Richard Cullen (Kent, Eng) </A><BR><I>by John Cullen, Dick Cullen, & Johnnie Wayne Brown</I></LI>


### PR DESCRIPTION
In `CullData.html` under list `Other Cullen Family Histories Contributed`, there was a list item that had two open a tags (`<A>`).